### PR TITLE
Add support for CameraLink based systems to odin-data

### DIFF
--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -125,7 +125,7 @@ public:
   void update(const IpcMessage& other);
 
   //! Updates parameters from a rapidJSON object.
-  void update(rapidjson::Value& params);
+  void update(const rapidjson::Value& param_val, std::string param_prefix="");
 
   //! Gets the value of a named parameter in the message.
   //!

--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -121,13 +121,11 @@ public:
              MsgVal msg_val=MsgValIllegal,
              bool strict_validation=true);
 
-  //! Update parameters from another IPCMessage.
-  //!
-  //! This will iterate the parameters in the given IPCMessage and set them on this instance.
-  //!
-  //! \param other - IPCMessage to take parameters from
-
+  //! Updates parameters from another IPCMessage.
   void update(const IpcMessage& other);
+
+  //! Updates parameters from a rapidJSON object.
+  void update(rapidjson::Value& params);
 
   //! Gets the value of a named parameter in the message.
   //!
@@ -313,6 +311,8 @@ public:
 
   //! Returns a JSON-encoded string of the message parameters at a specified path
   const char* encode_params(const std::string& param_path = std::string());
+
+  void encode_params(rapidjson::Value& param_obj, const std::string& param_path = std::string());
 
   //! Overloaded equality relational operator
   friend bool operator ==(IpcMessage const& lhs_msg, IpcMessage const& rhs_msg);

--- a/common/include/IpcMessage.h
+++ b/common/include/IpcMessage.h
@@ -63,7 +63,7 @@ private:
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/error/en.h"
-
+#include "rapidjson/pointer.h"
 
 namespace OdinData
 {
@@ -310,6 +310,9 @@ public:
 
   //! Returns a JSON-encoded string of the message
   const char* encode(void);
+
+  //! Returns a JSON-encoded string of the message parameters at a specified path
+  const char* encode_params(const std::string& param_path = std::string());
 
   //! Overloaded equality relational operator
   friend bool operator ==(IpcMessage const& lhs_msg, IpcMessage const& rhs_msg);

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -362,6 +362,38 @@ const char* IpcMessage::encode(void)
   return encode_buffer_.GetString();
 }
 
+//! Returns a JSON-encoded string of the message parameters at a specified path
+//!
+//! This method returns a JSON-encoded sting version of the parameters associated with the message,
+//! or a subset of those at a specified slash-delimted path.
+//!
+//! \param param_path - JSON pointer-like slash delimited path into the parameter block
+//! \return  JSON encoded parameters as a null-terminated, string character array
+
+const char* IpcMessage::encode_params(const std::string& param_path)
+{
+
+  // Construct a JSON pointer string to the message parameters. If a path argument was specified
+  // append that accordingly.
+  std::string path = "/params";
+  if (!param_path.empty())
+  {
+    path = path + "/" + param_path;
+  }
+
+  // Resolve the pointer to the appropriate location in the parameters
+  const rapidjson::Value* param_ptr = rapidjson::Pointer(path.c_str()).Get(doc_);
+
+  // Clear the encode buffer, create a writer and associate with the parameter pointer
+  encode_buffer_.Clear();
+  rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<> > writer(encode_buffer_);
+  param_ptr->Accept(writer);
+
+  // Return the string encoding of the requested parameters
+  return encode_buffer_.GetString();
+}
+
+
 //! Overloaded equality relational operator.
 //!
 //! This function overloads the equality relational operator, allowing two

--- a/common/src/IpcMessage.cpp
+++ b/common/src/IpcMessage.cpp
@@ -160,14 +160,28 @@ void IpcMessage::update(const IpcMessage& other)
 //! This method will update the parameters in message with the contents of the specified
 //! JSON object.
 //!
-//! \param params - RapidJSON value object of parameters
+//! \param param_val - RapidJSON value object of parameters
+//! \param param_prefix - string prefix for parameter path to set
 
-void IpcMessage::update(rapidjson::Value& params)
+void IpcMessage::update(const rapidjson::Value& param_val, std::string param_prefix)
 {
-    for (rapidjson::Value::ConstMemberIterator itr = params.MemberBegin();
-        itr != params.MemberEnd(); ++itr)
+    if (param_val.IsObject())
     {
-        this->set_param<const rapidjson::Value&>(itr->name.GetString(), itr->value);
+      for (rapidjson::Value::ConstMemberIterator itr = param_val.MemberBegin();
+          itr != param_val.MemberEnd(); ++itr)
+      {
+
+          std::string param_path = itr->name.GetString();
+          if (!param_prefix.empty())
+          {
+            param_path = param_prefix + "/" + param_path;
+          }
+          this->update(itr->value, param_path);
+      }
+    }
+    else
+    {
+      this->set_param<const rapidjson::Value&>(param_prefix, param_val);
     }
 }
 

--- a/frameProcessor/src/Acquisition.cpp
+++ b/frameProcessor/src/Acquisition.cpp
@@ -641,7 +641,7 @@ std::string Acquisition::generate_filename(size_t file_number) {
   std::stringstream generated_filename;
 
   char number_string[7];
-  snprintf(number_string, 7, "%06d", file_number + 1);
+  snprintf(number_string, 7, "%06ld", file_number + 1);
   if (!configured_filename_.empty())
   {
     generated_filename << configured_filename_ << "_" << number_string << file_extension_;

--- a/frameProcessor/src/FrameProcessorController.cpp
+++ b/frameProcessor/src/FrameProcessorController.cpp
@@ -621,8 +621,8 @@ void FrameProcessorController::loadPlugin(const std::string& index, const std::s
       plugin->connect_meta_channel();
       plugins_[index] = plugin;
 
-      // Register callback to FWC with FileWriter plugin
-      if (name == "FileWriter") {
+      // Register callback to controller with FileWriter plugin
+      if (name == "FileWriterPlugin") {
         plugin->register_callback("controller", this->shared_from_this(), true);
       }
 
@@ -738,10 +738,11 @@ void FrameProcessorController::shutdown() {
     pluginShutdownSent_ = true;
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Plugin shutdown sent. Removing plugins once stopped.");
     // Wait until each plugin has stopped and erase it from our map
-    for (it = plugins_.begin(); it != plugins_.end(); it++) {
+    it = plugins_.begin();
+    while(it != plugins_.end()) {
       LOG4CXX_DEBUG_LEVEL(1, logger_, "Removing " << it->first);
       while(it->second->isWorking());
-      plugins_.erase(it);
+      plugins_.erase(it++);
     }
 
     // Stop worker thread (for IFrameCallback) and reactor

--- a/frameProcessor/src/LiveViewPlugin.cpp
+++ b/frameProcessor/src/LiveViewPlugin.cpp
@@ -30,7 +30,8 @@ const std::string LiveViewPlugin::CONFIG_TAGGED_FILTER_NAME = "filter_tagged";
  */
 LiveViewPlugin::LiveViewPlugin() :
     publish_socket_(ZMQ_PUB),
-    is_bound_(false)
+    is_bound_(false),
+    time_last_frame_(boost::posix_time::min_date_time)
 {
   logger_ = Logger::getLogger("FP.LiveViewPlugin");
   LOG4CXX_INFO(logger_, "LiveViewPlugin version " << this->get_version_long() << " loaded");

--- a/frameReceiver/include/CMakeLists.txt
+++ b/frameReceiver/include/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Install header files into installation prefix
 
-SET(HEADERS FrameDecoder.h FrameDecoderUDP.h FrameDecoderZMQ.h)
+SET(HEADERS FrameDecoder.h FrameDecoderUDP.h FrameDecoderZMQ.h FrameDecoderCameraLink.h)
 INSTALL(FILES ${HEADERS} DESTINATION include/frameReceiver)

--- a/frameReceiver/include/FrameDecoder.h
+++ b/frameReceiver/include/FrameDecoder.h
@@ -70,7 +70,7 @@ public:
 
   void register_buffer_manager(OdinData::SharedBufferManagerPtr buffer_manager);
   void register_frame_ready_callback(FrameReadyCallback callback);
-  void push_empty_buffer(int buffer_id);
+  virtual void push_empty_buffer(int buffer_id);
   const size_t get_num_empty_buffers(void) const;
   const size_t get_num_mapped_buffers(void) const;
   void drop_all_buffers(void);

--- a/frameReceiver/include/FrameDecoderCameraLink.h
+++ b/frameReceiver/include/FrameDecoderCameraLink.h
@@ -1,6 +1,9 @@
 /*
  * FrameDecoderCameraLink.h
  *
+ * Abstract base class for frameReceiver decoder implementations for CameraLink-based
+ * systems.
+ *
  *  Created on: July 27, 2021
  *      Author: Tim Nicholls, STFC Detector Sytems Software Group
  */
@@ -17,6 +20,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include <log4cxx/logger.h>
 using namespace log4cxx;
@@ -27,6 +31,7 @@ using namespace log4cxx::helpers;
 
 namespace FrameReceiver
 {
+
 class FrameDecoderCameraLink : public FrameDecoder
 {
 public:
@@ -36,7 +41,34 @@ public:
   {
   };
 
+  virtual void start_camera_service(std::string& notify_endpoint) = 0;
+  virtual void stop_camera_service(void) = 0;
   virtual ~FrameDecoderCameraLink() = 0;
+
+  void push_empty_buffer(int buffer_id)
+  {
+    boost::lock_guard<boost::mutex> lock(mutex_);
+    FrameDecoder::push_empty_buffer(buffer_id);
+  }
+
+  bool get_empty_buffer(int& buffer_id, void*& buffer_addr)
+  {
+    boost::lock_guard<boost::mutex> lock(mutex_);
+
+    bool buffer_avail = !empty_buffer_queue_.empty();
+
+    if (buffer_avail)
+    {
+      buffer_id = empty_buffer_queue_.front();
+      empty_buffer_queue_.pop();
+      buffer_addr = buffer_manager_->get_buffer_address(buffer_id);
+    }
+
+    return buffer_avail;
+  }
+
+private:
+  boost::mutex mutex_;
 
 };
 

--- a/frameReceiver/include/FrameDecoderCameraLink.h
+++ b/frameReceiver/include/FrameDecoderCameraLink.h
@@ -54,11 +54,11 @@ namespace FrameReceiver
     virtual void handle_ctrl_channel(void) = 0;
     void push_empty_buffer(int buffer_id);
     bool get_empty_buffer(int& buffer_id, void*& buffer_addr);
+    void notify_frame_ready(int buffer_id, int frame_number);
 
   protected:
 
     virtual void run_camera_service(void) = 0;
-    void notify_frame_ready(int buffer_id, int frame_number);
 
     OdinData::IpcChannel ctrl_channel_;
     std::string ctrl_endpoint_;

--- a/frameReceiver/include/FrameDecoderCameraLink.h
+++ b/frameReceiver/include/FrameDecoderCameraLink.h
@@ -1,0 +1,48 @@
+/*
+ * FrameDecoderCameraLink.h
+ *
+ *  Created on: July 27, 2021
+ *      Author: Tim Nicholls, STFC Detector Sytems Software Group
+ */
+
+#ifndef INCLUDE_FRAMEDECODER_CAMERALINK_H_
+#define INCLUDE_FRAMEDECODER_CAMERALINK_H_
+
+#include <queue>
+#include <map>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <netinet/in.h>
+
+#include <boost/shared_ptr.hpp>
+#include <boost/function.hpp>
+
+#include <log4cxx/logger.h>
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+#include "DebugLevelLogger.h"
+
+#include "FrameDecoder.h"
+
+namespace FrameReceiver
+{
+class FrameDecoderCameraLink : public FrameDecoder
+{
+public:
+
+  FrameDecoderCameraLink() :
+      FrameDecoder()
+  {
+  };
+
+  virtual ~FrameDecoderCameraLink() = 0;
+
+};
+
+inline FrameDecoderCameraLink::~FrameDecoderCameraLink() {};
+
+typedef boost::shared_ptr<FrameDecoderCameraLink> FrameDecoderCameraLinkPtr;
+
+} // namespace FrameReceiver
+#endif /* INCLUDE_FRAMEDECODER_CAMERALINK_H_ */

--- a/frameReceiver/include/FrameReceiverCameraLinkRxThread.h
+++ b/frameReceiver/include/FrameReceiverCameraLinkRxThread.h
@@ -20,6 +20,7 @@ using namespace log4cxx::helpers;
 #include "IpcMessage.h"
 #include "IpcReactor.h"
 #include "SharedBufferManager.h"
+#include "FrameReceiverDefaults.h"
 #include "FrameDecoderCameraLink.h"
 #include "FrameReceiverConfig.h"
 #include "FrameReceiverRxThread.h"
@@ -29,6 +30,7 @@ using namespace OdinData;
 
 namespace FrameReceiver
 {
+
 class FrameReceiverCameraLinkRxThread : public FrameReceiverRxThread
 {
 public:
@@ -39,10 +41,13 @@ public:
 private:
 
   void run_specific_service(void);
+  void handle_notify_channel(void);
   void cleanup_specific_service(void);
 
   LoggerPtr                 logger_;
   FrameDecoderCameraLinkPtr frame_decoder_;
+  IpcChannel                notify_channel_;
+  std::string               notify_endpoint_;
 
 };
 

--- a/frameReceiver/include/FrameReceiverCameraLinkRxThread.h
+++ b/frameReceiver/include/FrameReceiverCameraLinkRxThread.h
@@ -1,0 +1,50 @@
+/*!
+ * FrameReceiverCameraLinkThread.h
+ *
+ *  Created on: July 27, 2021
+ *      Author: Tim Nicholls, STFC Detector Systems software Group
+ */
+
+#ifndef FRAMERECEIVERCAMERALINKRXTHREAD_H_
+#define FRAMERECEIVERCAMERALINKRXTHREAD_H_
+
+#include <boost/thread.hpp>
+#include <boost/asio.hpp>
+
+#include <log4cxx/logger.h>
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+#include "DebugLevelLogger.h"
+
+#include "IpcChannel.h"
+#include "IpcMessage.h"
+#include "IpcReactor.h"
+#include "SharedBufferManager.h"
+#include "FrameDecoderCameraLink.h"
+#include "FrameReceiverConfig.h"
+#include "FrameReceiverRxThread.h"
+#include "OdinDataException.h"
+
+using namespace OdinData;
+
+namespace FrameReceiver
+{
+class FrameReceiverCameraLinkRxThread : public FrameReceiverRxThread
+{
+public:
+  FrameReceiverCameraLinkRxThread(FrameReceiverConfig& config, SharedBufferManagerPtr buffer_manager,
+      FrameDecoderPtr frame_decoder, unsigned int tick_period_ms=100);
+  virtual ~FrameReceiverCameraLinkRxThread();
+
+private:
+
+  void run_specific_service(void);
+  void cleanup_specific_service(void);
+
+  LoggerPtr                 logger_;
+  FrameDecoderCameraLinkPtr frame_decoder_;
+
+};
+
+} // namespace FrameReceiver
+#endif /* FRAMERECEIVERCAMERALINKRXTHREAD_H_ */

--- a/frameReceiver/include/FrameReceiverConfig.h
+++ b/frameReceiver/include/FrameReceiverConfig.h
@@ -103,6 +103,8 @@ public:
       rx_name_map["UDP"] = Defaults::RxTypeUDP;
       rx_name_map["zmq"]  = Defaults::RxTypeZMQ;
       rx_name_map["ZMQ"]  = Defaults::RxTypeZMQ;
+      rx_name_map["cameralink"] = Defaults::RxTypeCameraLink;
+      rx_name_map["CameraLink"] = Defaults::RxTypeCameraLink;
     }
 
     if (rx_name_map.count(rx_name)){
@@ -122,6 +124,7 @@ public:
     {
       rx_type_map[Defaults::RxTypeUDP] = "udp";
       rx_type_map[Defaults::RxTypeZMQ] = "zmq";
+      rx_type_map[Defaults::RxTypeCameraLink] = "cameralink";
       rx_type_map[Defaults::RxTypeIllegal] = "unknown";
     }
 

--- a/frameReceiver/include/FrameReceiverController.h
+++ b/frameReceiver/include/FrameReceiverController.h
@@ -27,6 +27,7 @@
 #include "FrameReceiverRxThread.h"
 #include "FrameReceiverUDPRxThread.h"
 #include "FrameReceiverZMQRxThread.h"
+#include "FrameReceiverCameraLinkRxThread.h"
 #include "FrameDecoder.h"
 #include "OdinDataException.h"
 #include "ClassLoader.h"

--- a/frameReceiver/include/FrameReceiverDefaults.h
+++ b/frameReceiver/include/FrameReceiverDefaults.h
@@ -25,6 +25,7 @@ enum RxType
   RxTypeIllegal = -1,
   RxTypeUDP,
   RxTypeZMQ,
+  RxTypeCameraLink,
 };
 
 const int          default_node                   = 1;

--- a/frameReceiver/include/FrameReceiverDefaults.h
+++ b/frameReceiver/include/FrameReceiverDefaults.h
@@ -42,6 +42,7 @@ const int          default_rx_recv_buffer_size    = 1048576;
 const int          default_rx_recv_buffer_size    = 30000000;
 #endif
 const std::string  default_rx_chan_endpoint       = "inproc://rx_channel";
+const std::string  default_notify_endpoint        = "inproc://notify_channel";
 const std::string  default_ctrl_chan_endpoint     = "tcp://*:5000";
 const std::string  default_frame_ready_endpoint   = "tcp://*:5001";
 const std::string  default_frame_release_endpoint = "tcp://*:5002";

--- a/frameReceiver/include/FrameReceiverRxThread.h
+++ b/frameReceiver/include/FrameReceiverRxThread.h
@@ -60,6 +60,7 @@ protected:
 
   FrameReceiverConfig&   config_;
   IpcReactor             reactor_;
+  IpcChannel             rx_channel_;          //!< Channel for communication with the main thread
 
 private:
 
@@ -78,7 +79,6 @@ private:
   unsigned int           tick_period_ms_;      //!< Receiver thread tick timer period
 
   boost::shared_ptr<boost::thread> rx_thread_; //!< Pointer to RX thread
-  IpcChannel             rx_channel_;          //!< Channel for communication with the main thread
   std::vector<int>       recv_sockets_;        //!< List of receive socket file descriptors
 
   bool                   run_thread_;          //!< Flag signalling thread should run

--- a/frameReceiver/src/CMakeLists.txt
+++ b/frameReceiver/src/CMakeLists.txt
@@ -15,7 +15,8 @@ file(GLOB APP_SOURCES FrameReceiverApp.cpp
                       FrameReceiverController.cpp
                       FrameReceiverRxThread.cpp
                       FrameReceiverUDPRxThread.cpp
-                      FrameReceiverZMQRxThread.cpp )
+                      FrameReceiverZMQRxThread.cpp
+                      FrameReceiverCameraLinkRxThread.cpp)
 
 add_executable(frameReceiver ${APP_SOURCES})
 

--- a/frameReceiver/src/CMakeLists.txt
+++ b/frameReceiver/src/CMakeLists.txt
@@ -4,7 +4,7 @@ ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 
 include_directories(${FRAMERECEIVER_DIR}/include ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
-file(GLOB LIB_SOURCES FrameDecoder.cpp)
+file(GLOB LIB_SOURCES FrameDecoder.cpp FrameDecoderCameraLink.cpp)
 
 # Add library for common plugin code
 add_library(${LIB_RECEIVER} SHARED ${LIB_SOURCES})

--- a/frameReceiver/src/FrameDecoderCameraLink.cpp
+++ b/frameReceiver/src/FrameDecoderCameraLink.cpp
@@ -1,0 +1,206 @@
+/*
+ * FrameDecoderCameraLink.cpp
+ *
+ * Abstract base class for frameReceiver decoder implementations for CameraLink-based
+ * systems.
+ *
+ *  Created on: July 27, 2021
+ *      Author: Tim Nicholls, STFC Detector Sytems Software Group
+ */
+#include "FrameDecoderCameraLink.h"
+
+const std::string default_camera_ctrl_endpoint = "tcp://*:5060";
+
+using namespace FrameReceiver;
+using namespace OdinData;
+
+//! Constructor for the FrameDecoderCameraLink class.
+//!
+//! This method initialises the base class of each CameraLink base class, setting
+//! default values for base confoiguration parameters and variables.
+//!
+FrameDecoderCameraLink::FrameDecoderCameraLink() :
+  FrameDecoder(),
+  ctrl_channel_(ZMQ_ROUTER),
+  ctrl_endpoint_(default_camera_ctrl_endpoint),
+  run_thread_(false),
+  notify_channel_(ZMQ_PAIR)
+{
+};
+
+//! Initialise the FrameDecoderCameraLink instance
+//!
+//! This method initialises the base FrameDecoderCameraLink instance, extracting and storing
+//! parameters from the configuration message.
+//!
+//! \param[in] config_msg - IpcMessage containing decoder configuration parameters
+//!
+void FrameDecoderCameraLink::init(OdinData::IpcMessage& config_msg)
+{
+  // Pass the configuration message to the base class initialisation method
+  FrameDecoder::init(config_msg);
+
+  // Update configuration parameters if found in the config message
+  ctrl_endpoint_ = config_msg.get_param<std::string>(
+    CONFIG_DECODER_CAMERA_CTRL_ENDPOINT, ctrl_endpoint_
+  );
+
+}
+
+//! Start the decoder camera service
+//!
+//! This method starts the decoder camera service. Called from the context of the receiver thread
+//! this binds the camera control channel and registers it with the receiver thread reactor and
+//! then launches a new thread running the camera service.
+//!
+//! \param[in] notify_endpoint - IpcChannel endpoint for cross-thread buffer ready notification
+//! \param[in] rxthread_reactor - RX thread reactor to register camera control thread with
+//!
+void FrameDecoderCameraLink::start_camera_service(
+  std::string& notify_endpoint, OdinData::IpcReactor& rxthread_reactor)
+{
+
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Starting camera service");
+
+  notify_endpoint_ = notify_endpoint;
+
+  // Bind the camera control channel to the endpoint
+  try
+  {
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Binding camera control channel to endpoint: " << ctrl_endpoint_);
+    ctrl_channel_.bind(ctrl_endpoint_);
+  }
+  catch (zmq::error_t e)
+  {
+    std::stringstream sstr;
+    sstr << "Binding control channel endpoint " << ctrl_endpoint_ << " failed: " << e.what();
+    throw OdinData::OdinDataException(sstr.str());
+  }
+
+  // Register the control channel with the RX thread reactor
+  rxthread_reactor.register_channel(ctrl_channel_,
+    boost::bind(&FrameDecoderCameraLink::handle_ctrl_channel, this)
+  );
+
+  // Start the camera service thread
+  run_thread_ = true;
+  camera_thread_.reset(new boost::thread(
+    boost::bind(&FrameDecoderCameraLink::run_camera_service_internal, this)
+  ));
+
+}
+
+//! Stop the camera service thread
+//!
+//! this method stops the running camera service thread. The run_thread_ flag is set to flase,
+//! allowing the thread event loop to terminate cleanly and then the thread is joined.
+//!
+void FrameDecoderCameraLink::stop_camera_service(void)
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Stopping camera service thread");
+
+  run_thread_ = false;
+  if (camera_thread_) {
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Waiting for camera service thread to stop....");
+    camera_thread_->join();
+  }
+
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Camera service thread stopped");
+}
+
+
+//! Push a buffer onto the empty buffer queue
+//!
+//! This method adds an empty shared memory buffer onto the decoder internal empty buffer
+//! queue. This is simply a call to the base class method wrapped in a mutex to allow the
+//! queue to be safely used across the context of both the RX and camera controller threads.
+//!
+//! \param[in] buffer_id - SharedBufferManager buffer ID
+//!
+void FrameDecoderCameraLink::push_empty_buffer(int buffer_id)
+{
+  boost::lock_guard<boost::mutex> lock(mutex_);
+  FrameDecoder::push_empty_buffer(buffer_id);
+}
+
+//! Get a buffer from the empty buffer queue
+//!
+//! This method checks if a buffer ie available on the decoder internal empty buffer queue
+//! and, if so, pops one off the queue and determines the buffer id and address. This is
+//! wrapped in a mutex to allow thread-safe use.
+//!
+//! TODO the underlying logic should be devolved to the base FrameDecoder class
+//!
+//! \param[out] buffer_id - ID of next empty buffer from queue
+//! \param[out] buffer_addr - address of next emptty buffer from queue
+//! \return boolean value, true if buffer available, false if not
+//!
+bool FrameDecoderCameraLink::get_empty_buffer(int& buffer_id, void*& buffer_addr)
+{
+  boost::lock_guard<boost::mutex> lock(mutex_);
+
+  // Check if queue is not empty
+  bool buffer_avail = !empty_buffer_queue_.empty();
+
+  // If buffer available, get ID and address and pop off the front of the queue
+  if (buffer_avail)
+  {
+    buffer_id = empty_buffer_queue_.front();
+    empty_buffer_queue_.pop();
+    buffer_addr = buffer_manager_->get_buffer_address(buffer_id);
+  }
+
+  return buffer_avail;
+}
+
+//! Notify the RX thread that a filled buffer is ready
+//!
+//! This protected method is used to allow the camera service thread in a decoder
+//! to notify the RX thread that a filled buffer is ready to be passed on for
+//! downstream processing.
+//!
+//! \param[in] buffer_id - ID of the shared buffer
+//! \param[in] frame_namber - frame number filled into the shared buffer
+//!
+void FrameDecoderCameraLink::notify_frame_ready(int buffer_id, int frame_number)
+{
+  LOG4CXX_DEBUG_LEVEL(2, logger_,
+    "Notifying frame " << frame_number << " ready in buffer " << buffer_id);
+
+  IpcMessage ready_msg(IpcMessage::MsgTypeNotify, IpcMessage::MsgValNotifyFrameReady);
+  ready_msg.set_param("frame", frame_number);
+  ready_msg.set_param("buffer_id", buffer_id);
+
+  notify_channel_.send(ready_msg.encode());
+
+}
+
+//! Internal camera service thread runner
+//!
+//! This private method implements the camera service thread. This first connects the buffer
+//! notifier channel to the RX thread and then calls the decoder-specific camera service method.
+//!
+void FrameDecoderCameraLink::run_camera_service_internal(void)
+{
+
+// Connect the notify channel to the RX thread
+  try
+  {
+    LOG4CXX_DEBUG_LEVEL(1, logger_,
+      "Connecting notify channel to endpoint " << notify_endpoint_);
+    notify_channel_.connect(notify_endpoint_);
+  }
+  catch (zmq::error_t& e)
+  {
+    std::stringstream ss;
+    ss << "Connecting notify channel to endpoint " << notify_endpoint_
+      << " failed: " << e.what();
+    //this->set_thread_init_error(ss.str());
+    return;
+  }
+
+  // Run the decoder-specific camera service
+  this->run_camera_service();
+
+}
+

--- a/frameReceiver/src/FrameReceiverCameraLinkRxThread.cpp
+++ b/frameReceiver/src/FrameReceiverCameraLinkRxThread.cpp
@@ -16,7 +16,9 @@ FrameReceiverCameraLinkRxThread::FrameReceiverCameraLinkRxThread(FrameReceiverCo
                                                    FrameDecoderPtr frame_decoder,
                                                    unsigned int tick_period_ms) :
     FrameReceiverRxThread(config, buffer_manager, frame_decoder, tick_period_ms),
-    logger_(log4cxx::Logger::getLogger("FR.CameraLinkRxThread"))
+    logger_(log4cxx::Logger::getLogger("FR.CameraLinkRxThread")),
+    notify_channel_(ZMQ_PAIR),
+    notify_endpoint_(Defaults::default_notify_endpoint)
 {
   LOG4CXX_DEBUG_LEVEL(1, logger_, "FrameReceiverCameraLinkRxThread constructor entered....");
 
@@ -32,9 +34,60 @@ FrameReceiverCameraLinkRxThread::~FrameReceiverCameraLinkRxThread()
 void FrameReceiverCameraLinkRxThread::run_specific_service(void)
 {
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Running CameraLink RX thread service");
+
+  // Bind the notify channel to its endpoint
+  try
+  {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Binding notify channel to endpoint " << notify_endpoint_);
+    notify_channel_.bind(notify_endpoint_);
+  }
+  catch (zmq::error_t& e)
+  {
+    std::stringstream ss;
+    ss << "Binding notify channel to endpoint " << notify_endpoint_ << "failed: " << e.what();
+      this->set_thread_init_error(ss.str());
+      return;
+  }
+
+  // Add the notify channel to the reactor
+  reactor_.register_channel(notify_channel_,
+    boost::bind(&FrameReceiverCameraLinkRxThread::handle_notify_channel, this));
+
+  // Start the camera-specific service implemented by the decoder
+  frame_decoder_->start_camera_service(notify_endpoint_);
+}
+
+void FrameReceiverCameraLinkRxThread::handle_notify_channel(void)
+{
+  std::string notify_msg_encoded = notify_channel_.recv();
+
+  try
+  {
+    IpcMessage notify_msg(notify_msg_encoded.c_str());
+    IpcMessage::MsgType msg_type = notify_msg.get_msg_type();
+    IpcMessage::MsgVal msg_val = notify_msg.get_msg_val();
+
+    if ((msg_type == IpcMessage::MsgTypeNotify) && (msg_val == IpcMessage::MsgValNotifyFrameReady))
+    {
+      LOG4CXX_DEBUG_LEVEL(2, logger_, "Got frame ready notification from notify channel"
+        << " for frame " << notify_msg.get_param<int>("frame", -1)
+        << " in buffer  " << notify_msg.get_param<int>("buffer_id", -1)
+      );
+      rx_channel_.send(notify_msg_encoded);
+    }
+    else
+    {
+      LOG4CXX_ERROR(logger_, "Got unexpected messsage on notify channel: " << notify_msg_encoded);
+    }
+  }
+  catch (IpcMessageException& e)
+  {
+    LOG4CXX_ERROR(logger_, "Error decoding notify channel message: " << e.what());
+  }
 }
 
 void FrameReceiverCameraLinkRxThread::cleanup_specific_service(void)
 {
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Cleaning up CameraLink RX thread service");
+  frame_decoder_->stop_camera_service();
 }

--- a/frameReceiver/src/FrameReceiverCameraLinkRxThread.cpp
+++ b/frameReceiver/src/FrameReceiverCameraLinkRxThread.cpp
@@ -54,7 +54,7 @@ void FrameReceiverCameraLinkRxThread::run_specific_service(void)
     boost::bind(&FrameReceiverCameraLinkRxThread::handle_notify_channel, this));
 
   // Start the camera-specific service implemented by the decoder
-  frame_decoder_->start_camera_service(notify_endpoint_);
+  frame_decoder_->start_camera_service(notify_endpoint_, reactor_);
 }
 
 void FrameReceiverCameraLinkRxThread::handle_notify_channel(void)

--- a/frameReceiver/src/FrameReceiverCameraLinkRxThread.cpp
+++ b/frameReceiver/src/FrameReceiverCameraLinkRxThread.cpp
@@ -1,0 +1,40 @@
+/*!
+ * FrameReceiverCameraLinkRxThread.cpp
+ *
+ *  Created on: July 27, 2021
+ *      Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#include <unistd.h>
+
+#include "FrameReceiverCameraLinkRxThread.h"
+
+using namespace FrameReceiver;
+
+FrameReceiverCameraLinkRxThread::FrameReceiverCameraLinkRxThread(FrameReceiverConfig& config,
+                                                   SharedBufferManagerPtr buffer_manager,
+                                                   FrameDecoderPtr frame_decoder,
+                                                   unsigned int tick_period_ms) :
+    FrameReceiverRxThread(config, buffer_manager, frame_decoder, tick_period_ms),
+    logger_(log4cxx::Logger::getLogger("FR.CameraLinkRxThread"))
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "FrameReceiverCameraLinkRxThread constructor entered....");
+
+  // Store the frame decoder as a CameraLink type frame decoder
+  frame_decoder_ = boost::dynamic_pointer_cast<FrameDecoderCameraLink>(frame_decoder);
+}
+
+FrameReceiverCameraLinkRxThread::~FrameReceiverCameraLinkRxThread()
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Destroying FrameReceiverCameraLinkRxThread....");
+}
+
+void FrameReceiverCameraLinkRxThread::run_specific_service(void)
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Running CameraLink RX thread service");
+}
+
+void FrameReceiverCameraLinkRxThread::cleanup_specific_service(void)
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Cleaning up CameraLink RX thread service");
+}

--- a/frameReceiver/src/FrameReceiverController.cpp
+++ b/frameReceiver/src/FrameReceiverController.cpp
@@ -704,7 +704,7 @@ void FrameReceiverController::configure_rx_thread(OdinData::IpcMessage& config_m
 
     // Clear the RX thread configuration status until succesful completion
     rx_thread_configured_ = false;
-        
+
     if (frame_decoder_ && buffer_manager_)
     {
 
@@ -721,11 +721,15 @@ void FrameReceiverController::configure_rx_thread(OdinData::IpcMessage& config_m
           rx_thread_.reset(new FrameReceiverZMQRxThread(config_, buffer_manager_, frame_decoder_));
           break;
 
+        case Defaults::RxTypeCameraLink:
+          rx_thread_.reset(new FrameReceiverCameraLinkRxThread(config_, buffer_manager_, frame_decoder_));
+          break;
+
         default:
           throw FrameReceiverException("Cannot create RX thread - RX type not recognised");
       }
 
-      // Start the RX thread, Flagging successful completion of configuration
+      // Start the RX thread, flagging successful completion of configuration
       rx_thread_configured_ = rx_thread_->start();
 
     }


### PR DESCRIPTION
This PR adds an integration to odin-data to allow CameraLink based systems to be read out with odin-data. Specifically it adds support for a frameReceiver decoder and RX thread that support control of and image acquisition from CameraLink systems. The RX thread integrates an IpcChannel for control of the camera and an additional readout event loop.

Note this does NOT introduce a dependency on any libraries supporting CameraLink hardware; those are typically vendor specific (camera and frame grabber card) and are therefore dependencies of any project-specific decoder implementation.

Minor bug fixes across odin-data to support compilation and operation on Ubuntu systems with e.g. later boost versions, are also included.